### PR TITLE
moved non-conda packages to pip section of StreamCat.yml

### DIFF
--- a/StreamCat.yml
+++ b/StreamCat.yml
@@ -24,7 +24,6 @@ dependencies:
 - cloudpickle=0.3.1=py27_0
 - colorama=0.3.9=py27_0
 - configparser=3.5.0=py27_0
-- curl=7.52.1=vc9_0
 - cycler=0.10.0=py27_0
 - dask=0.14.3=py27_0
 - decorator=4.0.11=py27_0
@@ -33,20 +32,11 @@ dependencies:
 - docutils=0.13.1=py27_0
 - entrypoints=0.2.2=py27_1
 - enum34=1.1.6=py27_1
-- expat=2.1.0=vc9_2
-- fiona=1.7.7=np112py27_0
-- freetype=2.7=vc9_1
-- freexl=1.0.2=vc9_1
 - functools32=3.2.3.2=py27_1
 - futures=3.0.5=py27_0
-- gdal=2.2.0=np112py27_vc9_0
 - geopandas=0.2.1=py27_4
-- geos=3.5.1=vc9_1
-- hdf4=4.2.12=vc9_0
-- hdf5=1.8.17=vc9_11
 - heapdict=1.0.0=py27_0
 - html5lib=0.999=py27_0
-- icu=58.1=vc9_1
 - idna=2.5=py27_0
 - imageio=2.2.0=py27_0
 - imagesize=0.7.1=py27_0
@@ -59,23 +49,12 @@ dependencies:
 - jedi=0.10.0=py27_0
 - jinja2=2.9.5=py27_0
 - jmespath=0.9.2=py27_0
-- jpeg=9b=vc9_0
 - jsonschema=2.5.1=py27_0
 - jupyter=1.0.0=py27_0
 - jupyter_client=5.0.1=py27_0
 - jupyter_console=5.1.0=py27_0
 - jupyter_core=4.3.0=py27_0
-- kealib=1.4.7=vc9_0
-- krb5=1.14.2=vc9_0
 - lazy-object-proxy=1.3.0=py27_0
-- libiconv=1.14=vc9_4
-- libnetcdf=4.4.1.1=vc9_4
-- libpng=1.6.28=vc9_0
-- libpq=9.5.4=vc9_4
-- libspatialindex=1.8.5=vc9_1
-- libspatialite=4.3.0a=vc9_15
-- libtiff=4.0.6=vc9_7
-- libxml2=2.9.4=vc9_4
 - locket=0.2.0=py27_1
 - markupsafe=1.0=py27_0
 - matplotlib=2.0.2=np112py27_0
@@ -89,8 +68,6 @@ dependencies:
 - notebook=5.0.0=py27_0
 - numpydoc=0.6.0=py27_0
 - olefile=0.44=py27_0
-- openjpeg=2.1.2=vc9_2
-- openssl=1.0.2h=vc9_3
 - packaging=16.8=py27_0
 - pandas=0.20.2=np112py27_0
 - pandoc=1.19.2=0
@@ -101,7 +78,6 @@ dependencies:
 - pickleshare=0.7.3=py27_0
 - pillow=4.1.1=py27_0
 - pip=9.0.1=py27_0
-- proj4=4.9.3=vc9_3
 - prompt_toolkit=1.0.14=py27_0
 - psutil=5.2.1=py27_0
 - psycopg2=2.7.1=py27_0
@@ -120,12 +96,9 @@ dependencies:
 - pytz=2017.2=py27_0
 - pywavelets=0.5.2=np112py27_0
 - pyyaml=3.12=py27_1
-- pyzmq=16.0.2=py27_2
-- qt=5.6.2=vc9_1
 - qtawesome=0.4.4=py27_0
 - qtconsole=4.3.0=py27_0
 - qtpy=1.2.1=py27_0
-- rasterio=1.0a9=np112py27_0
 - requests=2.17.3=py27_0
 - rope=0.10.5=py27_0
 - rtree=0.8.3=py27_0
@@ -146,7 +119,6 @@ dependencies:
 - sphinxcontrib-websupport=1.0.1=py27_0
 - spyder=3.1.4=py27_0
 - sqlalchemy=1.1.5=py27_0
-- sqlite=3.13.0=vc9_1
 - ssl_match_hostname=3.5.0.1=py27_1
 - tblib=1.3.2=py27_0
 - testpath=0.3=py27_0
@@ -155,27 +127,55 @@ dependencies:
 - traitlets=4.3.2=py27_0
 - typing=3.6.1=py27_0
 - urllib3=1.21.1=py27_1
-- vc=9=0
 - wcwidth=0.1.7=py27_0
 - webencodings=0.5=py27_0
 - wheel=0.29.0=py27_0
 - widgetsnbextension=2.0.0=py27_0
-- win_inet_pton=1.0.1=py27_1
-- win_unicode_console=0.5=py27_0
-- wincertstore=0.2=py27_0
 - wrapt=1.10.8=py27_0
-- xerces-c=3.1.4=vc9_3
-- yaml=0.1.6=vc9_0
 - zict=0.1.2=py27_0
-- zlib=1.2.11=vc9_0
 - asn1crypto=0.22.0=py27_0
 - cryptography=1.8.1=py27_0
-- libgdal=2.0.0=vc9_1
 - mkl=2017.0.1=0
 - numpy=1.12.1=py27_0
 - scipy=0.19.0=np112py27_0
-- vs2008_runtime=9.00.30729.5054=0
 - pip:
+  - libgdal=2.0.0=vc9_1
+  - geos=3.5.1=vc9_1
+  - win_inet_pton=1.0.1=py27_1
+  - expat=2.1.0=vc9_2
+  - icu=58.1=vc9_1
+  - freexl=1.0.2=vc9_1
+  - xerces-c=3.1.4=vc9_3
+  - win_unicode_console=0.5=py27_0
+  - pyzmq=16.0.2=py27_2
+  - yaml=0.1.6=vc9_0
+  - rasterio=1.0a9=np112py27_0
+  - proj4=4.9.3=vc9_3
+  - gdal=2.2.0=np112py27_vc9_0
+  - vs2008_runtime=9.00.30729.5054=0
+  - fiona=1.7.7=np112py27_0
+  - zlib=1.2.11=vc9_0
+  - libnetcdf=4.4.1.1=vc9_4
+  - libpng=1.6.28=vc9_0
+  - libtiff=4.0.6=vc9_7
+  - libxml2=2.9.4=vc9_4
+  - libspatialite=4.3.0a=vc9_15
+  - vc=9=0
+  - kealib=1.4.7=vc9_0
+  - qt=5.6.2=vc9_1
+  - libiconv=1.14=vc9_4
+  - hdf4=4.2.12=vc9_0
+  - hdf5=1.8.17=vc9_11
+  - jpeg=9b=vc9_0
+  - libspatialindex=1.8.5=vc9_1
+  - krb5=1.14.2=vc9_0
+  - sqlite=3.13.0=vc9_1
+  - curl=7.52.1=vc9_0
+  - openjpeg=2.1.2=vc9_2
+  - freetype=2.7=vc9_1
+  - wincertstore=0.2=py27_0
+  - libpq=9.5.4=vc9_4
+  - openssl=1.0.2h=vc9_3
   - backports-abc==0.5
   - backports.functools-lru-cache==1.3
   - backports.shutil-get-terminal-size==1.0.0


### PR DESCRIPTION
I attempted to create a conda environment for StreamCat using the first two methods suggested in the readme (conda cloud and the .yml file). Both resulted in ResolvePackageNotFound errors. By editing the .yml file so that all unresolved packages were moved to the pip section, I was able to install all packages and create the environment.