### PR TITLE
FinalTableName needs to be CanalDensity for CanalsDitches.tif layer

### DIFF
--- a/MakeFinalTables.py
+++ b/MakeFinalTables.py
@@ -95,7 +95,7 @@ for table in tables:
                             tbl[fnlname2] = tbl['Ws' + sname] / (tbl[wsArea] * (tbl[wsPct]/100)) 
                             sumL.append(fnlname1)
                             sumL.append(fnlname2)
-                    if table == 'RoadStreamCrossings' or table == 'CanalsDitches':
+                    if table == 'RoadStreamCrossings' or table == 'CanalDensity':
                         tbl[colname1] = (tbl.CatSum / (tbl.CatAreaSqKm * (tbl.CatPctFull/100)) * conversion) ## NOTE:  Will there ever be a situation where we will need to use 'conversion' here
                         tbl[colname2] = (tbl.WsSum / (tbl.WsAreaSqKm * (tbl.WsPctFull/100)) * conversion)                        
                     else:


### PR DESCRIPTION
this is the line in MakeFinalTables.py that caused all of the output tables to be filled with `33.3333333`. I've made the updated tables in `L:/Priv/CORFiles/Geospatial_Library_Projects/StreamCat/FTP_Staging/StreamCat/HydroRegions/junk` for checking and they seem to be right, though I am not specifically sure of the values or why we used the conversion value of `0.03`.