### PR TITLE
remove env arg in create with package defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you are using Anaconda, creating a new, clean 'StreamCat' environment with th
   + conda env create -f streamcat_py3.yml
   
 * To build environment yourself, do:
-  + conda env create --name StreamCat -c conda-forge python=3.6 geopandas rasterio=1.1.5=py36h2409764_0
+  + conda create --name StreamCat -c conda-forge python=3.6 geopandas rasterio=1.1.5=py36h2409764_0
 
 * To activate this new environment, you'll need to install Spyder in the environment, and possibly re-install pyqt with specific version (we did).  You may even need to uninstall pyqt after installing Spyder (as below) and then specifically re-install:
 


### PR DESCRIPTION
this command as is will error...
`conda env` is used when pointing to a file or to an anaconda account like is done in the first example

```
rick@y:~$ conda env --help
usage: conda-env [-h] {create,export,list,remove,update,config} ...

positional arguments:
  {create,export,list,remove,update,config}
    create              Create an environment based on an environment file
```

I've also noticed on my machine that the `arcpy` files that you point to are all in a different location for me, can you confirm that your's aren't in the same place as well?

`C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\Lib\site-packages`

you had pointed to 
`C:\Program Files\ArcGIS\Pro\bin\Python\envs\arcgispro-py3\` in the README