### PR TITLE
remove masks from ControlTable rows in Ag metrics

### DIFF
--- a/ControlTable_StreamCat.csv
+++ b/ControlTable_StreamCat.csv
@@ -1,6 +1,6 @@
 FullTableName,accum_type,MetricName,AppendMetric,LandscapeLayer,summaryfield,Final_Table_Name,MetricType,Conversion,by_RPU,use_mask,run,notes
-Ag2006HiSlp,Categorical,lookup/Ag2006HiSlp_lookup.csv,none,Ag2006HiSlp.tif,,AgMidHiSlopes,Percent,1,0,2,0,"run w/ mask, but no AppendMetric"
-Ag2006MidSlp,Categorical,lookup/Ag2006MidSlp_lookup.csv,none,Ag2006MidSlp.tif,,AgMidHiSlopes,Percent,1,0,3,0,"run w/ mask, but no AppendMetric"
+Ag2006HiSlp,Categorical,lookup/Ag2006HiSlp_lookup.csv,none,Ag2006HiSlp.tif,,AgMidHiSlopes,Percent,1,0,0,0,
+Ag2006MidSlp,Categorical,lookup/Ag2006MidSlp_lookup.csv,none,Ag2006MidSlp.tif,,AgMidHiSlopes,Percent,1,0,0,0,
 AgDrain,Categorical,lookup/AgDrain_lookup.csv,none,AgDrain_stlvl_FINAL.tif,,AgDrain,Percent,1,0,0,0,
 AgKffact,Continuous,AgKffact,none,AgKffact.tif,,Kffact,Mean,0.01,0,0,0,
 Al2O3,Continuous,Al2O3,none,al20mar14.tif,,GeoChemPhys1,Mean,1,0,0,0,
@@ -10,14 +10,14 @@ bedrock_perm,Continuous,lookup/bedrock_perm_lookup.csv,none,bedrock_perm.tif,,be
 BFI,Continuous,BFI,none,bfi48grd.tif,,BFI,Mean,1,0,0,0,
 CanalDensity,Continuous,CanalDens,none,CanalsDitches.tif,,CanalDensity,Density,0.03,0,0,0,
 CaO,Continuous,CaO,none,cao20mar14.tif,,GeoChemPhys1,Mean,1,0,0,0,
-CBNF,Continuous,CBNF,none,cbnf.tif,,AgriculturalNitrogen,Mean,1,0,1,0,
+CBNF,Continuous,CBNF,none,cbnf.tif,,AgriculturalNitrogen,Mean,1,0,0,0,
 Clay,Continuous,Clay,none,clay.tif,,STATSGO_Set1,Mean,0.01,0,0,0,
 CoalMines,Point,CoalMineDens,none,USTRAT.shp,,CoalMines,Density,1,0,0,0,
 CompStrgth,Continuous,CompStrgth,none,ucs20mar14.tif,,GeoChemPhys4,Mean,1,0,0,0,
 Dams,Point,DamDens,none,dams.shp,NIDStorM3;NrmStorM3,Dams,Density,1,0,0,0,
 Elev,Continuous,Elev,none,elev_cm,,Elevation,Mean,0.01,1,0,0,Elevation takes an extremely long time to run..by_RPU
 Fe2O3,Continuous,Fe2O3,none,fe20mar14.tif,,GeoChemPhys1,Mean,1,0,0,0,
-Fert,Continuous,Fert,none,fert.tif,,AgriculturalNitrogen,Mean,1,0,1,0,
+Fert,Continuous,Fert,none,fert.tif,,AgriculturalNitrogen,Mean,1,0,0,0,
 Fire2000,Continuous,PctFire2000,none,fire2000.tif,,FirePerimeters,Mean,100,0,0,0,
 Fire2000_RipBuf100,Continuous,PctFire2000,Rp100,fire2000.tif,,FirePerimetersRipBuf100,Mean,100,0,1,0,
 Fire2001,Continuous,PctFire2001,none,fire2001.tif,,FirePerimeters,Mean,100,0,0,0,
@@ -49,7 +49,7 @@ K2O,Continuous,K2O,none,k20mar14.tif,,GeoChemPhys1,Mean,1,0,0,0,
 Kffact,Continuous,Kffact,none,kffact.tif,,Kffact,Mean,0.01,0,0,0,used to create the pctfull on the rp100 rasters
 lith,Categorical,lookup/Lithology_lookup.csv,none,us_lithology_1km_dd83.tif,,Lithology,Percent,1,0,0,0,
 lstfrz,Continuous,LST32F,none,lstfrz.tif,,lstfrz,Mean,1,0,0,0,
-Manure,Continuous,Manure,none,manure.tif,,AgriculturalNitrogen,Mean,1,0,1,0,
+Manure,Continuous,Manure,none,manure.tif,,AgriculturalNitrogen,Mean,1,0,0,0,
 MgO,Continuous,MgO,none,mgo20mar14.tif,,GeoChemPhys1,Mean,1,0,0,0,
 Mine,Point,MineDens,none,mines.shp,,Mines,Density,1,0,0,0,
 Mine_RipBuf100,Point,MineDens,Rp100,mines_RpBuf100.shp,,MinesRipBuf100,Density,1,0,1,0,

--- a/MakeFinalTables.py
+++ b/MakeFinalTables.py
@@ -195,43 +195,6 @@ for table, metrics in tables.items():
             if len(final[np.isinf(final)].stack().dropna()) > 0:
                 # inf values in dams layer - vpu 01 remove
                 final = final.replace([np.inf, -np.inf], np.nan) 
-<<<<<<< HEAD
-            if zone == '04':
-                rmtbl = pd.read_csv('L:/Priv/CORFiles/Geospatial_Library_Projects/StreamCat/FTP_Staging/Documentation/DataProcessingAndQualityAssurance/QA_Files/ProblemStreamsR04.csv')[['COMID']]
-                final = final.drop(rmtbl.COMID.tolist(),axis=0)
-            if zone == '06':
-                stats = {}
-                for c in final.columns.tolist():
-                    stats[c] = {'min': final[c].min(), 'max':final[c].max()}
-            if zone != '06':
-                try:
-                    stats
-                except NameError:
-                    pass
-                else:
-                    for c in final.columns.tolist():
-                        if final[c].min() < stats[c]['min']:
-                            stats[c]['min'] = final[c].min()
-                        if final[c].max() > stats[c]['max']:
-                            stats[c]['max'] = final[c].max()
-            final = final.fillna('NA')
-            final = final[final.columns.tolist()[:5] + [x for x in final.columns[5:] if 'Cat' in x] + [x for x in final.columns[5:] if 'Ws' in x]].fillna('NA')
-            if 'ForestLossByYear0013' in table:
-                final.drop([col for col in final.columns if 'NoData' in col], axis=1, inplace=True)
-            if not LENGTHS[zone] == len(final):
-                print "Table %s length zone %s incorrect!!!!...check Allocation\
-                        and Accumulation results" % (table, zone)
-            final.to_csv(outDir  + '/%s_Region%s.csv'%(table,zone))
-    print table
-    try:
-        stats
-    except NameError:
-        pass
-    else:
-        for stat in stats:
-            print stat + ' ' + str(stats[stat])
-    print 'All Done.....'
-=======
             if vpu == "04":
                 rmtbl = pd.read_csv("L:/Priv/CORFiles/Geospatial_Library_Projects/StreamCat/FTP_Staging/Documentation/DataProcessingAndQualityAssurance/QA_Files/ProblemStreamsR04.csv")[["COMID"]]
                 final = final.drop(rmtbl.COMID.tolist())
@@ -316,13 +279,3 @@ for table, metrics in tables.items():
 #    orig = pd.read_csv(STATES_DIR / f)
 #    new = pd.read_csv(REDO_STATES / f)
 #    print(table, state, orig.equals(new))
-
-
-
-
-
-
-
-
-
->>>>>>> 465b8b5d4a242d0861bcd3f9181121b4f23b1842

--- a/StreamCat_functions.py
+++ b/StreamCat_functions.py
@@ -931,7 +931,7 @@ def createCatStats(
     except arcpy.ExecuteError:
         print(arcpy.GetMessages(2))
 
-    if len(mask_dir) > 1:
+    if mask_dir:
         nhdtbl = dbf2DF(
             "%s/NHDPlus%s/NHDPlus%s/NHDPlusCatchment/Catchment.dbf"
             % (NHD_dir, hydroregion, zone)


### PR DESCRIPTION
closes #74

this PR updates the ControlTable to run the AgriculturalNitrogen and AgMidHiSlope metrics w/o masks as well as updates the `MakeFinalTables.py`. 

> , after investigating the PctFull problems mentioned, I've found that there are only problems in the AgriculturalNitorgen (CBNF, Fert, Manure) files as well as with AgMidHisSlopes, that was all I found after scanning everything in AllocationandAccumulation where any PctFull column was > 100 anyway. I do have a question beforehand, I think what happened was when I reran everything earlier this summer I had combined ControlTables because prior to that I had been working off of just a local copy due to the nature of always having to replace the strings in the first 2 cols which we had setup before w/ what we now have in the config file. Anyway, when looking at the current ControlTable you will see that these metrics all specify the use of a mask, I'm not sure how or why they would have been that way for AgriculturalNitrogen because we never should have been running those with a mask, but with the AgMidHiSlopes I think that we used to run with a mask but later made the rasters out to be categorical and just use value 1 to indicate where those areas are. I'm pretty sure about this but just want to check to make sure, this is what would give us the percent of the entire catchment/up/ws that is comprised of the slope degree. If we use the mask that would only give us the percent area of given slope within the mask which is not what we want, right? I think earlier we had it configured to use the mask and then pick out values 81 & 82 from the NLCD which changed a long time ago, but remained in the control table that way because I deleted the wrong lines when I merged them together, so I think just changing the control table and re-running these will fix all of our problems. I've re-run the AgNitrogen metrics and they all look good, but just want to ask about this with the MidHiSlopes for a sanity check, thanks