### PR TITLE
Catch KeyError when metric already processed

### DIFF
--- a/StreamCat.py
+++ b/StreamCat.py
@@ -24,34 +24,20 @@
  > python StreamCat.py
  --------------------------------------------------------
 """
-# TODO: remake npz files for bastards only, don't retain comids w/o upstream!
-# TODO: calculate WS metrics by table math, not in numpy accumulation process
-# TODO: create function like findUpstreamNPY for up and ws
 
 import os
+from datetime import datetime as dt
+
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
-from datetime import datetime as dt
-from stream_cat_config import (
-    LYR_DIR,
-    NHD_DIR,
-    OUT_DIR,
-    mask_dir_RP100,
-    mask_dir_Slp10,
-    mask_dir_Slp20,
-    pct_full_file,
-    pct_full_file_RP100,
-)
-from StreamCat_functions import (
-    Accumulation,
-    appendConnectors,
-    createCatStats,
-    interVPU,
-    makeNumpyVectors,
-    nhd_dict,
-    PointInPoly,
-)
+
+from stream_cat_config import (LYR_DIR, NHD_DIR, OUT_DIR, mask_dir_RP100,
+                               mask_dir_Slp10, mask_dir_Slp20, pct_full_file,
+                               pct_full_file_RP100)
+from StreamCat_functions import (Accumulation, PointInPoly, appendConnectors,
+                                 createCatStats, interVPU, makeNumpyVectors,
+                                 nhd_dict)
 
 # Load table of layers to be run...
 ctl = pd.read_csv("ControlTable_StreamCat.csv")
@@ -69,9 +55,7 @@ if not os.path.exists("accum_npy"):
     # TODO: work out children OR bastards only
     makeNumpyVectors(inter_vpu, NHD_DIR)
 
-INPUTS = np.load(
-    "accum_npy/vpu_inputs.npy", allow_pickle=True
-).item()
+INPUTS = np.load("accum_npy/vpu_inputs.npy", allow_pickle=True).item()
 
 for _, row in ctl.query("run == 1").iterrows():
 
@@ -105,7 +89,11 @@ for _, row in ctl.query("run == 1").iterrows():
         if not os.path.exists(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv"):
             pre = f"{NHD_DIR}/NHDPlus{hydroregion}/NHDPlus{zone}"
             if not row.accum_type == "Point":
-                izd = f"{mask_dir}/{zone}.tif" if mask_dir else f"{pre}/NHDPlusCatchment/cat"
+                izd = (
+                    f"{mask_dir}/{zone}.tif"
+                    if mask_dir
+                    else f"{pre}/NHDPlusCatchment/cat"
+                )
                 cat = createCatStats(
                     row.accum_type,
                     LL,
@@ -124,49 +112,50 @@ for _, row in ctl.query("run == 1").iterrows():
                     points, zone, izd, pct_full, mask_dir, apm, summaryfield
                 )
             cat.to_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv", index=False)
-            in2accum = len(cat.columns)
     print("Cat Results Complete in : " + str(dt.now() - catTime))
-    try:
-        # if in2accum not defined...Cat process done,but error thrown in accum
-        in2accum
-    except NameError:
-        # get number of columns to test if accumulation needs to happen
-        in2accum = len(pd.read_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv").columns)
     accumTime = dt.now()
     for zone in INPUTS:
-        cat = pd.read_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv")
-        in2accum = len(cat.columns)
-        if len(cat.columns) == in2accum:
-            if zone in inter_vpu.ToZone.values:
-                cat = appendConnectors(cat, Connector, zone, inter_vpu)
-            accum = np.load(f"accum_npy/accum_{zone}.npz")
-            
-            cat.COMID = cat.COMID.astype(accum["comids"].dtype)
-            cat.set_index("COMID",inplace=True)
-            cat = cat.loc[accum["comids"]].reset_index().copy()                
-            
-            up = Accumulation(
-                cat, accum["comids"], accum["lengths"], accum["upstream"], "Up"
+        fn = f"{OUT_DIR}/{row.FullTableName}_{zone}.csv"
+        cat = pd.read_csv(fn)
+        if cat.columns.str.extract(r"^(UpCat|Ws)").any().bool():
+            print(
+                "\n!!!Processing Problem!!!\n\n"
+                f"'{row.FullTableName}' metric has already been run!\n"
+                "Be sure to delete the associated files in these folders to rerun:"
+                f"\n\t> {OUT_DIR}\n"
+                f"\t> {OUT_DIR}/DBF_stash  <-- not used in 'Point' metrics"
             )
+            sys.exit()
+        if zone in inter_vpu.ToZone.values:
+            cat = appendConnectors(cat, Connector, zone, inter_vpu)
+        accum = np.load(f"accum_npy/accum_{zone}.npz")
 
-            ws = Accumulation(
-                cat, accum["comids"], accum["lengths"], accum["upstream"], "Ws"
+        cat.COMID = cat.COMID.astype(accum["comids"].dtype)
+        cat.set_index("COMID", inplace=True)
+        cat = cat.loc[accum["comids"]].reset_index().copy()
+
+        up = Accumulation(
+            cat, accum["comids"], accum["lengths"], accum["upstream"], "Up"
+        )
+
+        ws = Accumulation(
+            cat, accum["comids"], accum["lengths"], accum["upstream"], "Ws"
+        )
+
+        if zone in inter_vpu.ToZone.values:
+            cat = pd.read_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv")
+        if zone in inter_vpu.FromZone.values:
+            interVPU(
+                ws,
+                cat.columns[1:],
+                row.accum_type,
+                zone,
+                Connector,
+                inter_vpu.copy(),
+                summaryfield,
             )
-
-            if zone in inter_vpu.ToZone.values:
-                cat = pd.read_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv")
-            if zone in inter_vpu.FromZone.values:
-                interVPU(
-                    ws,
-                    cat.columns[1:],
-                    row.accum_type,
-                    zone,
-                    Connector,
-                    inter_vpu.copy(),
-                    summaryfield,
-                )
-            upFinal = pd.merge(up, ws, on="COMID")
-            final = pd.merge(cat, upFinal, on="COMID")
-            final.to_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv", index=False)
+        upFinal = pd.merge(up, ws, on="COMID")
+        final = pd.merge(cat, upFinal, on="COMID")
+        final.to_csv(f"{OUT_DIR}/{row.FullTableName}_{zone}.csv", index=False)
     print("Accumulation Results Complete in : " + str(dt.now() - accumTime))
 print("total elapsed time " + str(dt.now() - totTime))


### PR DESCRIPTION
this was brought up by Jesse a couple of weeks ago with this error message causing problems:

`KeyError: "None of [Index([('W', 's', 'A', 'r', 'e', 'a', 'S', 'q', 'K', 'm'), ('W', 's', 'A', 'r', 'e', 'a', 'S', 'q', 'K', 'm')], dtype='object')] are in the [index]"”`

This branch will:
- [ ] Print error message out to user
- [ ] Exit script without Exception