### PR TITLE
Allow user to run specific zones.

### DIFF
--- a/StreamCat.py
+++ b/StreamCat.py
@@ -44,6 +44,7 @@ from stream_cat_config import (
     OUT_DIR,
     PCT_FULL_FILE,
     PCT_FULL_FILE_RP100,
+    USER_ZONES,
 )
 from StreamCat_functions import (
     Accumulation,
@@ -71,7 +72,7 @@ if not os.path.exists(OUT_DIR + "/DBF_stash"):
 
 if not os.path.exists(ACCUM_DIR):
     # TODO: work out children OR bastards only
-    makeNumpyVectors(inter_vpu, NHD_DIR)
+    makeNumpyVectors(inter_vpu, NHD_DIR, USER_ZONES)
 
 INPUTS = np.load(ACCUM_DIR +"/vpu_inputs.npy", allow_pickle=True).item()
 

--- a/stream_cat_config.py.template
+++ b/stream_cat_config.py.template
@@ -18,6 +18,9 @@ STATES_FILE = "/path/to/file/tl_2008_us_state.shp"
 
 ACCUM_DIR = "path/to/local/repository/accump_npy/"
 
+# to run other than all NHD zones, set this dict to e.g. {"04": "GL", "12": "TX"}
+# keys are UnitID and values are DrainageID, see ...\NHDPlusGlobalData\BoundaryUnit.dbf
+USER_ZONES = {}
 
 # location to write out accumulated StreamCat data <- this is intermediate
 OUT_DIR = "/path/to/write/out/files/to"


### PR DESCRIPTION
Also don't assume `geometry` field present in DBFs, these two changes allow other subcatchment network data massaged to look like NHD data to be used more easily.

As before, no worries if this isn't something you want to merge.

I originally added the setting as an env. var. which touched the code in less places but seemed inconsistent with the use of stream_cat_config.py for everything else.