### PR TITLE
Fix path interpretation for landscape layers.

### DIFF
--- a/StreamCat.py
+++ b/StreamCat.py
@@ -90,7 +90,7 @@ for _, row in ctl.query("run == 1").iterrows():
         mask_dir = ""
     layer = (
         row.LandscapeLayer
-        if os.sep in row.LandscapeLayer
+        if "/" in row.LandscapeLayer or "\\" in row.LandscapeLayer
         else (f"{LYR_DIR}/{row.LandscapeLayer}")
     )  # use abspath
     if isinstance(row.summaryfield, str):

--- a/StreamCat_functions.py
+++ b/StreamCat_functions.py
@@ -21,6 +21,7 @@ import os
 import sys
 import time
 from collections import OrderedDict, defaultdict, deque
+from pathlib import Path
 from typing import Generator
 
 import numpy as np
@@ -965,16 +966,18 @@ def createCatStats(
         arcpy.env.snapRaster = inZoneData
         if by_RPU == 0:
             if LandscapeLayer.count(".tif") or LandscapeLayer.count(".img"):
+                landscape_layer = Path(LandscapeLayer).stem  # / vs. \ agnostic
                 outTable = "%s/DBF_stash/zonalstats_%s%s%s.dbf" % (
                     out_dir,
-                    LandscapeLayer.split("/")[-1].split(".")[0],
+                    landscape_layer,
                     appendMetric,
                     zone,
                 )
             else:
+                landscape_layer = Path(LandscapeLayer).name  # / vs. \ agnostic
                 outTable = "%s/DBF_stash/zonalstats_%s%s%s.dbf" % (
                     out_dir,
-                    LandscapeLayer.split("/")[-1],
+                    landscape_layer,
                     appendMetric,
                     zone,
                 )


### PR DESCRIPTION
StreamCat was failing with a path to categorical image data outside the layers folder, either joining paths when it shouldn't, e.g. E:\path\to\layersE:/data/landcover.img, or failing to make a valid DBF name, e.g. ...\DBFStash\E:\data\landcover.img.  Changes make it work regardless of / or \ delimiters, previously it failed one way or the other whichever you used.

I suspect it was working with *continuous* raster data outside the layers folder because that doesn't need a DBF to be created - there were examples in the control table of image data stored elsewhere, but only for continuous.